### PR TITLE
Fix SRV types and glibc compatibility, with some small improvements

### DIFF
--- a/libresolv-sys/build.rs
+++ b/libresolv-sys/build.rs
@@ -7,13 +7,13 @@ use std::str;
 
 fn main() -> Result<(), Box<dyn Error>> {
     static BINDING: &str = "resolv.rs";
-    static HEADER: &str = "/usr/include/resolv.h";
+    let header = format!("{}/resolv.h", std::env::var("GLIBC_INCLUDE").unwrap_or("/usr/include".into()));
     let mut cmd;
     let mut output;
 
-    eprintln!("Generating binding {:?} from {:?} ...\n", BINDING, HEADER);
+    eprintln!("Generating binding {:?} from {:?} ...\n", BINDING, header);
     cmd = Command::new("bindgen");
-    cmd.args(["--with-derive-default", HEADER]);
+    cmd.args(["--with-derive-default", &header]);
     output = cmd.output()?;
     if !output.status.success() {
         let msg = str::from_utf8(output.stderr.as_slice())?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::ffi::{NulError, FromBytesWithNulError};
 use std::str::Utf8Error;
 use crate::Section;
 
+#[derive(Clone, PartialEq, Eq)]
 // Taken in part from glibc-2.23/resolv/herror.c h_errlist
 #[repr(i32)]
 pub enum ResolutionError {
@@ -31,6 +32,7 @@ impl fmt::Debug for ResolutionError {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
 pub enum Error {
     /// Name Resolution failed
     Resolver(ResolutionError),

--- a/src/record/cname.rs
+++ b/src/record/cname.rs
@@ -27,7 +27,7 @@ impl RecordData for CNAME {
             msg._eom,
             rr.rdata,
             buffer.as_mut_ptr() as *mut i8,
-            MAXDNAME as u64)
+            MAXDNAME as usize)
         };
         if size < 0 {
             return Err(Error::UncompressError);

--- a/src/record/mx.rs
+++ b/src/record/mx.rs
@@ -29,7 +29,7 @@ impl RecordData for MX {
             msg._eom,
             rr.rdata.offset(2),
             buffer.as_mut_ptr() as *mut i8,
-            MAXDNAME as u64)
+            MAXDNAME as usize)
         };
         if size < 0 {
             return Err(Error::UncompressError);

--- a/src/record/ns.rs
+++ b/src/record/ns.rs
@@ -27,7 +27,7 @@ impl RecordData for NS {
             msg._eom,
             rr.rdata,
             buffer.as_mut_ptr() as *mut i8,
-            MAXDNAME as u64)
+            MAXDNAME as usize)
         };
         if size < 0 {
             return Err(Error::UncompressError);

--- a/src/record/ptr.rs
+++ b/src/record/ptr.rs
@@ -27,7 +27,7 @@ impl RecordData for PTR {
             msg._eom,
             rr.rdata,
             buffer.as_mut_ptr() as *mut i8,
-            MAXDNAME as u64)
+            MAXDNAME as usize)
         };
         if size < 0 {
             return Err(Error::UncompressError);

--- a/src/record/soa.rs
+++ b/src/record/soa.rs
@@ -47,7 +47,7 @@ impl RecordData for SOA {
                 msg._eom,
                 rr.rdata.offset(offset),
                 buffer.as_mut_ptr() as *mut i8,
-                MAXDNAME as u64)
+                MAXDNAME as usize)
             };
             if count < 0 {
                 return Err(Error::UncompressError);
@@ -63,7 +63,7 @@ impl RecordData for SOA {
                 msg._eom,
                 rr.rdata.offset(offset),
                 buffer.as_mut_ptr() as *mut i8,
-                MAXDNAME as u64)
+                MAXDNAME as usize)
             };
             if count < 0 {
                 return Err(Error::UncompressError);

--- a/src/record/srv.rs
+++ b/src/record/srv.rs
@@ -32,7 +32,7 @@ impl RecordData for SRV {
                 msg._eom,
                 rr.rdata.offset(6),
                 buffer.as_mut_ptr() as *mut i8,
-                MAXHOSTNAMELEN as u64,
+                MAXHOSTNAMELEN as usize,
             )
         };
         if size < 0 {

--- a/src/record/srv.rs
+++ b/src/record/srv.rs
@@ -9,8 +9,8 @@ use std::slice;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SRV {
-    pub priority: i16,
-    pub weight: i16,
+    pub priority: u16,
+    pub weight: u16,
     pub port: u16,
     pub name: String,
 }
@@ -42,11 +42,11 @@ impl RecordData for SRV {
         Ok(SRV {
             priority: unsafe {
                 let slice: &[u8] = slice::from_raw_parts(rr.rdata.offset(0), 2);
-                BigEndian::read_i16(slice)
+                BigEndian::read_u16(slice)
             },
             weight: unsafe {
                 let slice: &[u8] = slice::from_raw_parts(rr.rdata.offset(2), 2);
-                BigEndian::read_i16(slice)
+                BigEndian::read_u16(slice)
             },
             port: unsafe {
                 let slice: &[u8] = slice::from_raw_parts(rr.rdata.offset(4), 2);

--- a/src/record/srv.rs
+++ b/src/record/srv.rs
@@ -7,7 +7,7 @@ use libresolv_sys::MAXHOSTNAMELEN;
 use std::ffi::CStr;
 use std::slice;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SRV {
     pub priority: i16,
     pub weight: i16,

--- a/src/response.rs
+++ b/src/response.rs
@@ -51,7 +51,7 @@ impl Flags {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Section {
     Question,
     Answer,


### PR DESCRIPTION
This PR:

  * Most importantly, fixes the types for SRV priority and weight. This is a backwards incompatible change.
  * Uses `usize` instead of `u64` to fix the build against glibc headers.
  * Makes it easier/possible to build this project with `glibc` headers installed to a different location.
  * Derives some types to make debugging/usage/testing more convenient.

I'm happy to split these up or make other adjustments as you see fit.