### PR TITLE
libresolv-sys: use bindgen package, update cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/libresolv-sys/lib.rs
 /libresolv-sys/resolv.rs
 /libresolv-sys/target
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ DNS resolution via glibc
 """
 edition = "2018"
 
+[workspace]
+members = ["libresolv-sys"]
+
 [dependencies]
 libc = "0.2"
 libresolv-sys = { path = "libresolv-sys", version = "0.4.0" }

--- a/libresolv-sys/Cargo.toml
+++ b/libresolv-sys/Cargo.toml
@@ -4,9 +4,13 @@ version = "0.4.0"
 authors = ["Mike Dilger <mike@optcomp.nz>"]
 links = "resolv"
 build = "build.rs"
+edition = "2021"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/mikedilger/resolv-rs"
 description = "Native bindings to the libresolv library"
+
+[build-dependencies]
+bindgen = "0.72"
 
 [lib]
 name = "libresolv_sys"

--- a/libresolv-sys/build.rs
+++ b/libresolv-sys/build.rs
@@ -1,57 +1,58 @@
 use std::error::Error;
-use std::fs::{self, File};
-use std::io::Write; // File.write_all()
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 
 fn main() -> Result<(), Box<dyn Error>> {
     static BINDING: &str = "resolv.rs";
-    let header = format!("{}/resolv.h", std::env::var("GLIBC_INCLUDE").unwrap_or("/usr/include".into()));
-    let mut cmd;
-    let mut output;
-
-    eprintln!("Generating binding {:?} from {:?} ...\n", BINDING, header);
-    cmd = Command::new("bindgen");
-    cmd.args(["--with-derive-default", &header]);
-    output = cmd.output()?;
-    if !output.status.success() {
-        let msg = str::from_utf8(output.stderr.as_slice())?;
-        eprintln!("\"\"\"\n{}\"\"\"\n", msg);
-        panic!("{:?}", cmd);
-    }
-
-    let lints = fs::read("resolv.lints")?;
-    let mut f = File::create(BINDING)?;
-    f.write_all(lints.as_slice())?;
-    f.write_all(output.stdout.as_slice())?;
-
-    eprintln!(
-        "Checking available libresolv adapters to the generated binding {:?} ...\n",
-        BINDING
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    let header = format!(
+        "{}/resolv.h",
+        std::env::var("GLIBC_INCLUDE").unwrap_or_else(|_| "/usr/include".into())
     );
+
+    eprintln!("Generating binding {BINDING:?} from {header:?} ...\n");
+    let bindings = bindgen::Builder::default()
+        .header(&header)
+        .derive_default(true)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    bindings.write_to_file(out_dir.join(BINDING))?;
+
+    eprintln!("Checking available libresolv adapters to the generated binding {BINDING:?} ...\n");
 
     let mut paths: Vec<PathBuf> = fs::read_dir("lib.d")?.map(|e| e.unwrap().path()).collect();
     paths.sort_unstable();
+    let mut selected_path = None;
     for path in paths.iter().rev() {
-        eprintln!("Trying {:?} ...\n", path);
-        fs::copy(path, "lib.rs")?;
-        cmd = Command::new("rustc");
+        eprintln!("Trying {:?} ...\n", path.display());
+        fs::copy(path, out_dir.join("lib.rs"))?;
+        let mut cmd = Command::new("rustc");
         cmd.args(["--emit", "dep-info=/dev/null", "lib.rs"]);
-        output = cmd.output()?;
+        cmd.current_dir(&out_dir);
+        let output = cmd.output()?;
         if output.status.success() {
             eprintln!("Success\n");
+            selected_path = Some(path.clone());
             break;
-        } else {
-            let msg = str::from_utf8(output.stderr.as_slice())?;
-            eprintln!("\"\"\"\n{}\"\"\"\n", msg);
-            fs::remove_file("lib.rs")?;
         }
+        let msg = str::from_utf8(output.stderr.as_slice())?;
+        eprintln!("\"\"\"\n{msg}\"\"\"\n");
+        fs::remove_file(out_dir.join("lib.rs"))?;
     }
 
-    if !output.status.success() {
-        panic!("None of the available adapters compiled successfully!");
-    }
+    let selected_path = selected_path.expect("No available adapters compiled successfully");
+    let adapter = fs::read_to_string(selected_path)?;
+    let generated = adapter.replace(
+        "mod resolv;",
+        r#"#[allow(dead_code, non_camel_case_types, non_snake_case, non_upper_case_globals, unused_imports)]
+mod resolv {
+    include!(concat!(env!("OUT_DIR"), "/resolv.rs"));
+}"#,
+    );
+    fs::write(out_dir.join("lib_generated.rs"), generated)?;
 
     println!("cargo:rustc-flags=-l resolv");
 

--- a/libresolv-sys/lib.rs
+++ b/libresolv-sys/lib.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/lib_generated.rs"));


### PR DESCRIPTION
This is for https://github.com/mikedilger/resolv-rs/issues/11, where the end goal is to publish the 0.4 version of these crates. 
The first step IMO is to publish the `libresolv-sys` crate. I've made some changes to make packaging work (and clean things up along the way):

- Use the bindgen crate as a build dependency instead of requiring users to have the bindgen CLI installed. This makes the crate much easier to build and prevents lines like this in CI scripts: https://github.com/deshaw/srv-rs/blob/ecf0a86560b920712c1570d7aee1bd5d4c646864/.github/workflows/rust.yml#L36
  - Unignore `lib.rs` to make this work 
- Fix all the lints in `build.rs`
- Specify an edition of 2021 (somewhat arbitrary) to prevent Cargo from defaulting to the ancient 2015 edition
- Create a workspace and add `libresolv-sys` to it

Before (doesn't package):

```console
> cargo package
   Packaging libresolv-sys v0.4.0 (/tmp/resolv-rs/libresolv-sys)
warning: ignoring library `libresolv_sys` as `lib.rs` is not included in the published package
error: failed to prepare local package for uploading

Caused by:
  no targets specified in the manifest
  either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present
```

After (packaging works!):

```console
> cargo package
   Packaging libresolv-sys v0.4.0 (/tmp/resolv-rs/libresolv-sys)
    Updating crates.io index
    Packaged 10 files, 15.3KiB (4.6KiB compressed)
   Verifying libresolv-sys v0.4.0 (/tmp/resolv-rs/libresolv-sys)
   Compiling clang-sys v1.8.1
   Compiling regex-automata v0.4.14
   Compiling libloading v0.8.9
   Compiling bindgen v0.72.1
   Compiling regex v1.12.3
   Compiling libresolv-sys v0.4.0 (/tmp/resolv-rs/target/package/libresolv-sys-0.4.0)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.23s
```

CC @mikedilger 